### PR TITLE
Scien 5 cards api

### DIFF
--- a/controllers/FlashcardController.mjs
+++ b/controllers/FlashcardController.mjs
@@ -5,32 +5,7 @@ const db = knex(config.development);
 
 export default class FlashcardController {
 
-  /**
-   * @function deleteAll
-   * @async
-   * @memberof FlashcardController
-   * @description Deletes all flashcards associated with a given collection_id.
-   *
-   * @param {Object} req - The Express request object.
-   * @param {Object} res - The Express response object.
-   * @param {Function} next - The next middleware function in the Express chain.
-   * @returns {Promise<void>} Nothing is returned.
-   */
-  static async deleteAll(req, res, next) {
-    try {
-      // Delete all flashcards associated with the collection_id
-      await db("flashcards")
-        .where({ collection_id: Number(req.params.collectionId) })
-        .del();
-
-      // Send a success response
-      res.status(200).json({ message: "All flashcards deleted successfully." });
-    } catch (error) {
-      // If an error occurs, pass it to the next middleware
-      next(error);
-    }
-  }
-
+  
   /**
    *@function delete
    *@async

--- a/routes/api.mjs
+++ b/routes/api.mjs
@@ -24,11 +24,9 @@ router.patch('/test', (req, res, next) => {
 });
 
 // Flashcards routes
-router.get('/flashcards/:collectionId', FlashcardController.getAll);
-router.post('/flashcards/:collectionId', FlashcardController.create);
 router.put('/flashcards/:id', FlashcardController.update);
 router.delete('/flashcards/:id', FlashcardController.delete );
-router.delete('/flashcards/deleteAll/:collectionId', FlashcardController.deleteAll );
+
 
 
 


### PR DESCRIPTION
### :sparkles: Description
This pull request implements CRUD (Create, Read, Update, Delete) operations for a flashcard controller. The following changes were made:

- FlashcardController was created to handle CRUD operations for flashcards.
- GET route was added to the apiRouter to retrieve all notes from the database.
- POST route was added to the apiRouter to create a new note.
- PUT route was added to the apiRouter to update an existing note.
- DELETE route was added to the apiRouter to delete a note.


### :link: Related Issues

[SCIEN-5](https://grizzly-ufo.atlassian.net/browse/SCIEN-5)

### :bulb: Additional Information

To test these changes, you can use a tool such as Postman to send requests to the API. To create a new note, send a POST request to /api/flashcards with a JSON payload containing the question, answer,  and collection_id of the flashcard. To retrieve all notes, send a GET request to /api/flashcards. To update a flashcard, send a PUT request to /api/flashcards/:id with a JSON payload containing the updated fields of the flashcard, where :id is the ID of the flashcard to be updated. To delete a flashcard, send a DELETE request to /api/flashcards/:id, where :id is the ID of the flashcard to be deleted.


**NOT READY TO BE MERGED**

**Update:** 
**READY TO BE MERGED**

[SCIEN-8]: https://grizzly-ufo.atlassian.net/browse/SCIEN-8?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SCIEN-5]: https://grizzly-ufo.atlassian.net/browse/SCIEN-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ